### PR TITLE
Add support for OpenBSD's mime.types file

### DIFF
--- a/mimetypes.el
+++ b/mimetypes.el
@@ -41,6 +41,7 @@
 
 (defvar mimetypes-known-files
   '("/etc/mime.types"
+    "/usr/share/misc/mime.types"
     "/etc/httpd/mime.types"
     "/etc/httpd/conf/mime.types"
     "/etc/apache/mime.types"


### PR DESCRIPTION
OpenBSD comes with a default list of mime types at /usr/share/misc/mime.types